### PR TITLE
fixed bug: Documents: Field name not clearly visible, ‘certificate’ &…

### DIFF
--- a/web/rainmaker/dev-packages/egov-tradelicence-dev/src/ui-containers-local/DownloadFileContainer/index.js
+++ b/web/rainmaker/dev-packages/egov-tradelicence-dev/src/ui-containers-local/DownloadFileContainer/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { MultiDownloadCard } from "egov-ui-framework/ui-molecules";
+import { MultiDownloadCard } from "../../ui-molecules-local/";
 import { connect } from "react-redux";
 import get from "lodash/get";
 import "./index.css";

--- a/web/rainmaker/dev-packages/egov-tradelicence-dev/src/ui-molecules-local/MultiDownloadCard/index.js
+++ b/web/rainmaker/dev-packages/egov-tradelicence-dev/src/ui-molecules-local/MultiDownloadCard/index.js
@@ -1,0 +1,91 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { withStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import Grid from "@material-ui/core/Grid";
+import classNames from "classnames";
+import Button from "@material-ui/core/Button";
+import LabelContainer from "egov-ui-framework/ui-containers/LabelContainer";
+import "./index.css";
+
+const styles = {
+  whiteCard: {
+    maxWidth: 250,
+    backgroundColor: "#FFFFFF",
+    paddingLeft: 8,
+    paddingRight: 0,
+    paddingTop: 11,
+    paddingBottom: 0,
+    marginRight: 16,
+    marginTop: 16
+  },
+  subtext: {
+    paddingTop: 7
+  },
+  body2: {
+    wordWrap: "break-word",
+	wordBreak: "break-all"
+  }
+};
+
+const documentTitle = {
+  color: "rgba(0, 0, 0, 0.87)",
+  fontFamily: "Roboto",
+  fontSize: "16px",
+  fontWeight: 400,
+  letterSpacing: "0.67px",
+  lineHeight: "19px",
+  wordBreak: "break-word"
+};
+
+function MultiCardDownloadGrid(props) {
+  const { classes, data, ...rest } = props;
+  return (
+    <Grid container {...rest}>
+      {data && data.length && data.map((item, key) => {
+        return (
+          <Grid
+            item
+            container
+            xs={12}
+            sm={4}
+            className={
+              props.backgroundGrey
+                ? classNames(classes.whiteCard, "background-grey")
+                : classes.whiteCard
+            }
+          >
+            <Grid xs={12}>
+              <LabelContainer
+                labelName={item.title}
+                labelKey={item.title}
+                style={documentTitle}
+              />
+            </Grid>
+            <Grid container>
+              <Grid xs={6} className={classes.subtext}>
+                <Typography className={classes.body2}>{item.name}</Typography>
+              </Grid>
+              <Grid xs={6} align="right">
+                <Button href={item.link} color="primary">
+                 
+				  {/* {item.linkText} */}
+                  Download
+                </Button>
+              </Grid>
+            </Grid>
+          </Grid>
+        );
+      })}
+    </Grid>
+  );
+}
+
+MultiCardDownloadGrid.propTypes = {
+  title: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  link: PropTypes.array.isRequired,
+  linktext: PropTypes.array.isRequired
+};
+
+export default withStyles(styles)(MultiCardDownloadGrid);

--- a/web/rainmaker/dev-packages/egov-tradelicence-dev/src/ui-molecules-local/index.js
+++ b/web/rainmaker/dev-packages/egov-tradelicence-dev/src/ui-molecules-local/index.js
@@ -71,6 +71,11 @@ const TlHowItWorks = Loadable({
   loading: () => <Loading />
 })
 
+const MultiDownloadCard = Loadable({
+  loader: () => import("./MultiDownloadCard"),
+  loading: () => <Loading />
+});
+
 export {
   TestMolecules,
   RadioButtonsGroup,
@@ -84,5 +89,6 @@ export {
   ActionDialog,
   Footer,
   TaskDialog,
-  TlHowItWorks
+  TlHowItWorks,
+  MultiDownloadCard
 };


### PR DESCRIPTION
… ‘driving’ should be in single line.